### PR TITLE
Threaded Execution

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,14 @@
 Changelog
 =========
 
-1.5 (unreleased)
+2.0 (unreleased)
 ----------------
+
+- Use ``argparse`` for better commandline help
+  [jensens]
+
+- Run tests in parallel using threading.
+  [jensens]
 
 - Do not fail if path for a package can not be found.
   [timo]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 2.0 (unreleased)
 ----------------
 
+- add regular expression filter argument for packages
+  [jensens]
+
 - Use ``argparse`` for better commandline help
   [jensens]
 

--- a/README.rst
+++ b/README.rst
@@ -72,9 +72,15 @@ All options are optional, so a minimal part looks like this::
 This creates a ``bin/test-all`` script that runs bin/test for all eggs (and
 their dependencies) specified in the [test] part.
 
+Run ``bin/test-all --help`` in order to see the possible options.
 
-Reporting bugs or asking questions
-----------------------------------
 
-Please report issues and questions at:
-https://github.com/plone/plone.recipe.alltests/issues
+Issues, Contributions, Source Code
+==================================
+
+Contributors please read the document `Process for Plone core's development <http://docs.plone.org/develop/plone-coredev/index.html>`_
+
+Sources are at the `Plone code repository hosted at Github <https://github.com/plone/plone.recipe.alltests>`_.
+
+File bugs, ideas or other feedback at the `Issue tracker <https://github.com/plone/plone.recipe.alltests/issues>`_.
+

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 def read(*rnames):
     return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
 
-version = '1.5.dev0'
+version = '2.0.dev0'
 
 setup(
     name='plone.recipe.alltests',

--- a/src/plone/recipe/alltests/__init__.py
+++ b/src/plone/recipe/alltests/__init__.py
@@ -1,8 +1,8 @@
-import os
-import re
-
+# -*- coding: utf-8 -*-
 from zc.buildout import easy_install
 from zc.recipe.egg import Egg
+import os
+import re
 
 
 EXCLUDE_PACKAGES = set((
@@ -28,7 +28,10 @@ class Recipe(object):
             if 'test' in self.buildout:
                 self.options['eggs'] = self.buildout['test'].get('eggs')
 
-        self.default_policy = self.options.get('default-policy', 'include').strip()
+        self.default_policy = self.options.get(
+            'default-policy',
+            'include'
+        ).strip()
 
         self.exclude = self.options.get('exclude', '').split()
         self.exclude_groups = self.options.get('exclude-groups', '').split()
@@ -102,7 +105,8 @@ class Recipe(object):
                                 packages.remove(p)
                     else:
                         groups[k] = v.split()
-                elif self.default_policy == 'exclude' and k in self.include_groups:
+                elif (self.default_policy == 'exclude'
+                      and k in self.include_groups):
                     groups[k] = v.split()
 
         easy_install.scripts(

--- a/src/plone/recipe/alltests/runner.py
+++ b/src/plone/recipe/alltests/runner.py
@@ -33,7 +33,8 @@ parser.add_argument(
 )
 parser.add_argument(
     "testparameters",
-    default=[],
+    nargs="*",
+    default='',
     help="Optional parameters passed to the testrunner (in quotes)",
 )
 
@@ -130,14 +131,26 @@ def main(config):
         )
 
     # start the threads with the queue workers
-    threads = []
-    for idx in range(arguments.threads):
-        thread = threading.Thread(target=worker, args=(idx, todos, errors))
-        thread.start()
-        threads.append(thread)
+    if arguments.threads > 1:
+        # use threading
+        print "Start testrunner Using {0} parallel threads".format(
+            arguments.threads
+        )
+        threads = []
+        for idx in range(arguments.threads):
+            thread = threading.Thread(
+                target=worker,
+                args=(idx, todos, errors)
+            )
+            thread.start()
+            threads.append(thread)
 
-    for thread in threads:
-        thread.join()
+        for thread in threads:
+            thread.join()
+    else:
+        # do not use threading
+        print "Start testrunner in serial processing mode."
+        worker(None, todos, errors)
 
     if len(errors):
         print "Packages with test failures:\n"


### PR DESCRIPTION
WIP (dont merge)

Done so far:
- by default serial execution w/o threads
- threaded execution of tests if requested
- uses `argparse` (supports `--help` and `--version`)
- `group` argument accept multiple groups
- new `threads` argument
- no support for python 2.6 any longer
- increased version to 2.0
- use future print as guido likes it
- other minor code modernizations

Problems to solve
[ ] output of threads is mixed
[ ] robot tests are not running on different zserver ports 
[ ] check what happens with xmltestreports?
