### PR TITLE
Do not fail if path for a package can not be found.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 1.5 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Do not fail if path for a package can not be found.
+  [timo]
 
 
 1.4 (2014-03-02)

--- a/src/plone/recipe/alltests/runner.py
+++ b/src/plone/recipe/alltests/runner.py
@@ -53,7 +53,10 @@ def main(args):
             if m in packages:
                 packages.remove(m)
         package = ' -s '.join(members)
-        path = ' --test-path '.join([paths.get(p) for p in members])
+        path = ' --test-path '.join([
+            paths.get(p) for p in members
+            if paths.get(p) is not None
+        ])
         name = 'group %s' % group
         value = run_test(name, testscript, path, arg, package)
         if value:


### PR DESCRIPTION
With this fix in place we will see import errors on specific packages instead of a failure without any hint what might have gone wrong.